### PR TITLE
center boards

### DIFF
--- a/games/pacman.html
+++ b/games/pacman.html
@@ -143,9 +143,6 @@
             } #undo, #redo {
                 width: auto !important;
                 opacity: 50%;
-            } #board {
-                white-space: pre;
-                text-align: center;
             } .pac.spooked {
                 animation: pac-power 0.5s infinite ease-in-out;
             } .blinky.spooked {
@@ -172,6 +169,20 @@
                 margin: auto;
                 left: 0;
                 right: 0;
+            } div.board {
+                position: absolute;
+                /*chrome doesn't like 100%*/
+                width: 99%;
+            } div.board#last-board {
+                position: relative;
+                /*fixes misalignment between relative and absolute divs*/
+                width: 100%;
+            } div.board > table {
+                white-space: pre;
+                margin: auto;
+                text-align: center;
+                position: relative;
+                z-index: 10;
             } .pac.running-out {
                 animation: pac-power 0.1s infinite ease-in-out;
             } .spooked.running-out {
@@ -390,23 +401,23 @@ ___________________
         <div>
             <h3>Time: <span id='time'>0:00</span></h3>
             <h1>-- Board --</h1>
-            <table id="sprites-pac" style="position: absolute; z-index: 10;">
+            <div class="board"><table id="sprites-pac" class="board-table">
                 <tr><td><span class="pac">C</span></td></tr>
-            </table>
-            <table id="sprites-bli" style="position: absolute; z-index: 10;">
+            </table></div>
+            <div class="board"><table id="sprites-bli" class="board-table">
                 <tr><td></td></tr>
-            </table>
-            <table id="sprites-ink" style="position: absolute; z-index: 10;">
+            </table></div>
+            <div class="board"><table id="sprites-ink" class="board-table">
                 <tr><td></td></tr>
-            </table>
-            <table id="sprites-pin" style="position: absolute; z-index: 10;">
+            </table></div>
+            <div class="board"><table id="sprites-pin" class="board-table">
                 <tr><td></td></tr>
-            </table>
-            <table id="sprites-cly" style="position: absolute; z-index: 10;">
+            </table></div>
+            <div class="board"><table id="sprites-cly" class="board-table">
                 <tr><td></td></tr>
-            </table>
-            <table id="targets" style="display: none; left: 0; right: 0; position: absolute; z-index: 100;"></table>
-            <table id="board"></table>
+            </table></div>
+            <div class="board"><table id="targets" class="board-table" style="display: none; left: 0; right: 0; z-index: 100;"></table></div>
+            <div class="board" id="last-board"><table id="board" class="board-table"></table></div>
 
             <div style="text-align: center;">
                 ><button onclick='face_up()' title="Face up">&Lambda;</button> <br>


### PR DESCRIPTION
Fixes the board centering by wrapping all boards in an absolute div, which then has an auto-margin relatively-positioned table in it.

Sorry for the fucked up diff, it looked fine when I committed it.